### PR TITLE
Fix PMI calculation for issue #137

### DIFF
--- a/home-choice-pro/models/affordability_calculator.py
+++ b/home-choice-pro/models/affordability_calculator.py
@@ -189,8 +189,6 @@ class AffordabilityCalculator:
         if loan_amount == 0 or max_home_price == 0:
             return 0.0
         loan_to_value_ratio = loan_amount / max_home_price
-        if loan_to_value_ratio <= 0.8:
-            return 0.0
         annual_premium = loan_amount * pmi
         monthly_premium = annual_premium / 12
         return monthly_premium


### PR DESCRIPTION
Removed if clause in _calculate_monthly_pmi_payment() function that returned 0 if the down payment was greater than or equal to 20% of total home value. This check will be implemented as a pop-up notification on the front end of the application instead.