### PR TITLE
Removed unused variable for issue #143

### DIFF
--- a/home-choice-pro/models/affordability_calculator.py
+++ b/home-choice-pro/models/affordability_calculator.py
@@ -188,7 +188,6 @@ class AffordabilityCalculator:
         loan_amount = self._calculate_total_loan_principal(max_home_price, down_payment)
         if loan_amount == 0 or max_home_price == 0:
             return 0.0
-        loan_to_value_ratio = loan_amount / max_home_price
         annual_premium = loan_amount * pmi
         monthly_premium = annual_premium / 12
         return monthly_premium


### PR DESCRIPTION
Removed unused loan_to_value variable. Verified that all calculation are still accurate by using https://usmortgagecalculator.org/ . The variable is no longer used because it's only purpose was to check if a user has supplied a down payment of greater than or equal to 20%. that check is now being handled as a pop up window on the front end.